### PR TITLE
chore: fix remaining phpstan errors

### DIFF
--- a/src/Controller/TagController.php
+++ b/src/Controller/TagController.php
@@ -55,20 +55,24 @@ class TagController extends AbstractController
     public function update(Request $request): JsonResponse
     {
         $data = json_decode($request->getContent(), true);
+        if (!is_array($data)) {
+            $data = [];
+        }
+
         $tagsToUpdate = new TagCollection();
         $notFound = new TagCollection();
+        /** @var array<int, array<string, mixed>> $newValuesByTagId */
+        $newValuesByTagId = [];
 
         foreach ($data as $t) {
+            if (!is_array($t)) continue;
             if (empty($t['id'])) continue;
 
             $tag = new Tag();
-            $tag->setId($t['id']); // seulement l’ID pour savoir qui comparer
+            $id = (int) $t['id'];
+            $tag->setId($id); // seulement l’ID pour savoir qui comparer
 
-            // on stocke aussi les nouvelles valeurs du payload dans un tableau générique
-            // (évite de setter un champ qui n’existe pas encore dans l’entité)
-            foreach ($t as $field => $value) {
-                $tag->{"__newValues"}[$field] = $value;
-            }
+            $newValuesByTagId[$id] = $t;
 
             $tagsToUpdate->addTag($tag);
         }
@@ -80,7 +84,7 @@ class TagController extends AbstractController
                 'message' => 'Aucun tag existant n\'a été fourni.'
             ], 404);
         }
-        $updated = $this->tagService->updateTags($tagsToUpdate);
+        $updated = $this->tagService->updateTags($tagsToUpdate, $newValuesByTagId);
 
         return $this->json([
             'updated' => $updated['updated']->getTags(),

--- a/src/Helper/DoctrineHelper.php
+++ b/src/Helper/DoctrineHelper.php
@@ -43,7 +43,7 @@ class DoctrineHelper
     /**
      * Remplit les propriétés d'une entité à partir d'un tableau.
      *
-     * @template T
+     * @template T of object
      * @param class-string<T>|T $entityOrClass Instance ou nom de la classe de l'entité
      * @param array<string, mixed> $data Tableau associatif [champ => valeur]
      * @param bool $useDoctrineColumns Si true, ne prend que les colonnes Doctrine scalaires (optionnel)
@@ -52,11 +52,21 @@ class DoctrineHelper
      */
     public static function populateEntityFromArray(string|object $entityOrClass, array $data, bool $useDoctrineColumns = true): object
     {
-        $entity = is_object($entityOrClass) ? $entityOrClass : new $entityOrClass();
+        if (is_object($entityOrClass)) {
+            $entity = $entityOrClass;
+            $className = $entity::class;
+        } else {
+            if (!class_exists($entityOrClass)) {
+                throw new \InvalidArgumentException(sprintf('Entity class "%s" does not exist.', $entityOrClass));
+            }
+
+            $className = $entityOrClass;
+            $entity = new $className();
+        }
+
         $columns = null;
 
-        if ($useDoctrineColumns && is_string($entityOrClass)) {
-            $className = is_string($entityOrClass) ? $entityOrClass : get_class($entity);
+        if ($useDoctrineColumns) {
             $columns = self::getDoctrineColumns($className);
         }
 

--- a/src/Service/TagService.php
+++ b/src/Service/TagService.php
@@ -90,12 +90,13 @@ class TagService implements TagServiceInterface
      * via applyNewValues / setFieldIfExists. Les entités mises à jour sont renvoyées,
      * ainsi que celles non trouvées en base.
      *
+     * @param array<int, array<string, mixed>> $newValuesByTagId
      * @return array{
      *     updated: TagCollection,   // Collection des entités mises à jour
      *     not_found: TagCollection  // Collection des entités non trouvées en base
      * }
      */
-    public function updateTags(TagCollection $tagCollection): array
+    public function updateTags(TagCollection $tagCollection, array $newValuesByTagId = []): array
     {
         $toUpdate = new TagCollection();
         $notFound = new TagCollection();
@@ -109,7 +110,8 @@ class TagService implements TagServiceInterface
                 continue;
             }
 
-            $this->applyNewValues($existing, $tag, $toUpdate);
+            $id = $tag->getId();
+            $this->applyNewValues($existing, $newValuesByTagId[$id] ?? [], $toUpdate);
         }
 
         $this->repository->updateTags($toUpdate);
@@ -130,10 +132,11 @@ class TagService implements TagServiceInterface
      * @param Tag           $payload  L'entité contenant les nouvelles valeurs
      * @param TagCollection $toUpdate La collection où ajouter les entités modifiées
      */
-    private function applyNewValues($existing, $payload, TagCollection $toUpdate): void
+    /**
+     * @param array<string, mixed> $newValues
+     */
+    private function applyNewValues(Tag $existing, array $newValues, TagCollection $toUpdate): void
     {
-        $newValues = $payload->__newValues ?? [];
-
         foreach ($newValues as $field => $value) {
             $this->setFieldIfExists($existing, $field, $value, $toUpdate);
         }
@@ -150,12 +153,11 @@ class TagService implements TagServiceInterface
      * @param mixed         $newValue La nouvelle valeur à appliquer
      * @param TagCollection $toUpdate La collection où ajouter l'entité si modifiée
      */
-    private function setFieldIfExists($entity, string $field, $newValue, TagCollection $toUpdate): void
+    /**
+     * Met a jour une propriete d'une entite si elle existe et que sa valeur est differente.
+     */
+    private function setFieldIfExists(Tag $entity, string $field, mixed $newValue, TagCollection $toUpdate): void
     {
-        if (!$entity instanceof Tag) {
-            return;
-        }
-
         if (!property_exists($entity, $field)) {
             return;
         }


### PR DESCRIPTION
## Summary

- Remove dynamic Tag update payload usage
- Replace Tag dynamic properties with explicit update values
- Fix DoctrineHelper PHPDoc/generic typing
- Add guards around dynamic class instantiation
- Bring PHPStan to zero errors

## Checks

- php vendor/bin/phpstan analyse --memory-limit=512M: OK
- php bin/phpunit: OK
- php bin/console doctrine:schema:validate: OK